### PR TITLE
Replace AuthzClient with Unirest

### DIFF
--- a/long-running-rest-workitem/pom.xml
+++ b/long-running-rest-workitem/pom.xml
@@ -86,11 +86,17 @@
         <groupId>org.kie</groupId>
         <artifactId>kie-internal</artifactId>
       </dependency>
-        <dependency>
-          <groupId>org.keycloak</groupId>
-          <artifactId>keycloak-authz-client</artifactId>
-          <version>22.0.1</version>
-        </dependency>
+      <dependency>
+        <groupId>com.konghq</groupId>
+        <artifactId>unirest-java</artifactId>
+        <version>3.11.09</version>
+        <classifier>standalone</classifier>
+      </dependency>
+      <dependency>
+        <groupId>com.konghq</groupId>
+        <artifactId>unirest-objectmapper-jackson</artifactId>
+        <version>3.11.09</version>
+    </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -156,6 +162,22 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.konghq</groupId>
+      <artifactId>unirest-java</artifactId>
+      <classifier>standalone</classifier>
+      <exclusions>
+        <exclusion>
+            <artifactId>commons-logging</artifactId>
+            <groupId>commons-logging</groupId>
+        </exclusion>
+    </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.konghq</groupId>
+      <artifactId>unirest-objectmapper-jackson</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <exclusions>
@@ -171,11 +193,6 @@
       <artifactId>template-resources</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>org.keycloak</groupId>
-      <artifactId>keycloak-authz-client</artifactId>
-    </dependency>
-
     <dependency>
       <groupId>org.jboss.resteasy</groupId>
       <artifactId>resteasy-undertow</artifactId>

--- a/long-running-rest-workitem/src/main/java/org/jbpm/process/longrest/authentication/KeycloakResponse.java
+++ b/long-running-rest-workitem/src/main/java/org/jbpm/process/longrest/authentication/KeycloakResponse.java
@@ -1,0 +1,54 @@
+package main.java.org.jbpm.process.longrest.authentication;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KeycloakResponse {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    /** Unit in second */
+    @JsonProperty("expires_in")
+    private int expiresIn;
+
+    /** Unit in second */
+    @JsonProperty("refresh_expires_in")
+    private int refreshExpiresIn;
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+    public int getExpiresIn() {
+        return expiresIn;
+    }
+
+    public void setExpiresIn(int expiresIn) {
+        this.expiresIn = expiresIn;
+    }
+
+    public int getRefreshExpiresIn() {
+        return refreshExpiresIn;
+    }
+
+    public void setRefreshExpiresIn(int refreshExpiresIn) {
+        this.refreshExpiresIn = refreshExpiresIn;
+    }
+}

--- a/long-running-rest-workitem/src/main/java/org/jbpm/process/longrest/authentication/OidcClient.java
+++ b/long-running-rest-workitem/src/main/java/org/jbpm/process/longrest/authentication/OidcClient.java
@@ -1,20 +1,28 @@
 package main.java.org.jbpm.process.longrest.authentication;
 
-import org.apache.http.impl.client.HttpClients;
+import kong.unirest.HttpResponse;
+import kong.unirest.MultipartBody;
+import kong.unirest.Unirest;
+import kong.unirest.UnirestException;
+import kong.unirest.jackson.JacksonObjectMapper;
 import org.jbpm.process.longrest.Constant;
-import org.keycloak.authorization.client.AuthzClient;
-import org.keycloak.authorization.client.Configuration;
 
-import java.util.Collections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.net.ssl.SSLHandshakeException;
 
 /**
  * Class to obtain an OIDC Access token. The environment variables: SSO_URL, SSO_REALM,
  * SSO_SERVICE_ACCOUNT_CLIENT, SSO_SERVICE_ACCOUNT_SECRET must be set to be able to use it
  */
 public class OidcClient {
+    private static final int MAX_RETRIES = 10;
 
+    static {
+        // Configure Unirest ObjectMapper
+        Unirest.config().setObjectMapper(new JacksonObjectMapper());
+    }
     private static final Logger logger = LoggerFactory.getLogger(OidcClient.class);
 
     public static String getAccessToken() {
@@ -30,19 +38,77 @@ public class OidcClient {
             return "";
         }
 
-        final Configuration configuration = new Configuration(
-                System.getenv(Constant.SSO_URL_VARIABLE),
-                System.getenv(Constant.SSO_REALM_VARIABLE),
-                System.getenv(Constant.SSO_SERVICE_ACCOUNT_CLIENT_VARIABLE),
-                Collections.singletonMap("secret", System.getenv(Constant.SSO_SERVICE_ACCOUNT_SECRET_VARIABLE)),
-                HttpClients.createDefault());
+        String keycloakEndpoint = keycloakEndpoint(System.getenv((Constant.SSO_URL_VARIABLE)), System.getenv(Constant.SSO_REALM_VARIABLE));
 
-        return AuthzClient.create(configuration).obtainAccessToken().getToken();
+        MultipartBody body = Unirest.post(keycloakEndpoint)
+                .field("grant_type", "client_credentials")
+                .field("client_id", System.getenv(Constant.SSO_SERVICE_ACCOUNT_CLIENT_VARIABLE))
+                .field("client_secret", System.getenv(Constant.SSO_SERVICE_ACCOUNT_SECRET_VARIABLE));
+
+        KeycloakResponse response = getKeycloakResponseWithRetries(body);
+        return response.getAccessToken();
     }
 
     private static void checkIfEnvironmentVariableExists(String environmentVariable) {
         if (System.getenv(environmentVariable) == null) {
             throw new RuntimeException("Environment Variable: " + environmentVariable + " is not set!");
+        }
+    }
+
+    static String keycloakEndpoint(String keycloakBaseUrl, String realm) {
+        String keycloakUrl = keycloakBaseUrl;
+
+        if (!keycloakBaseUrl.endsWith("/")) {
+            keycloakUrl = keycloakBaseUrl + "/";
+        }
+
+        return keycloakUrl + "realms/" + realm + "/protocol/openid-connect/token";
+    }
+
+    static KeycloakResponse getKeycloakResponseWithRetries(MultipartBody body) throws UnirestException {
+       int retries = 0;
+
+        while (true) {
+            try {
+                HttpResponse<KeycloakResponse> postResponse = body.asObject(KeycloakResponse.class);
+                return postResponse.getBody();
+            } catch (UnirestException e) {
+                if (e.getCause().getClass().equals(SSLHandshakeException.class)) {
+                    throw new RuntimeException(
+                            "Cannot reach the Keycloak server because of missing TLS certificates",
+                            e.getCause());
+                }
+                retries++;
+
+                if (retries > MAX_RETRIES) {
+                    // all hope is lost. Stop retrying
+                    throw e;
+                } else if (retries == MAX_RETRIES / 2) {
+                    // let the user know as she waits
+                    logger.info("Having difficulty reaching {}. Retrying again...", body.getUrl());
+                }
+                sleepExponentially(retries);
+                logger.debug("Retrying to reach: {}", body.getUrl());
+            }
+        }
+    }
+
+    /**
+     * Sleep starting from 100 milliseconds when retries = 0, and sleeping exponentially as the retries increase
+     *
+     * The math is millisecondsSleep = 100 * 2^(retries)
+     *
+     * @param retries number of retries attempted
+     */
+    private static void sleepExponentially(int retries) {
+
+        long amountOfSleep = (long) (100 * Math.pow(2, retries));
+        logger.debug("Sleeping for {} seconds", String.format("%.1f", amountOfSleep / 1000.0));
+
+        try {
+            Thread.sleep(amountOfSleep);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
         }
     }
 }


### PR DESCRIPTION
This is done because keycloak deps have weird class loading on EAP. I couldn't figure out how to resolve this so I just want to try Unirest.

**Thank you for submitting this pull request**

**JIRA**: _(please edit the JIRA link if it exists)_ 

[link](https://www.example.com)

**referenced Pull Requests**: _(please edit the URLs of referenced pullrequests if they exist)_

* paste the link(s) from GitHub here
* link 2
* link 3 etc.

<details>
<summary>
How to replicate CI configuration locally?
</summary>

Build Chain tool does "simple" maven build(s), the builds are just Maven commands, but because the repositories relates and depends on each other and any change in API or class method could affect several of those repositories there is a need to use [build-chain tool](https://github.com/kiegroup/github-action-build-chain) to handle cross repository builds and be sure that we always use latest version of the code for each repository.
 
[build-chain tool](https://github.com/kiegroup/github-action-build-chain) is a build tool which can be used on command line locally or in Github Actions workflow(s), in case you need to change multiple repositories and send multiple dependent pull requests related with a change you can easily reproduce the same build by executing it on Github hosted environment or locally in your development environment. See [local execution](https://github.com/kiegroup/github-action-build-chain#local-execution) details to get more information about it.
</details>

<details>
<summary>
How to retest this PR or trigger a specific build:
</summary>

* <b>a pull request</b> please add comment: <b>Jenkins retest this</b>
 
* <b>a full downstream build</b> please add comment: <b>Jenkins run fdb</b>
  
* <b>a compile downstream build</b> please  add comment: <b>Jenkins run cdb</b>

* <b>a full production downstream build</b> please add comment: <b>Jenkins execute product fdb</b>

* <b>an upstream build</b> please add comment: <b>Jenkins run upstream</b>
</details>
